### PR TITLE
A new echo, and some other tweaks

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -25,7 +25,7 @@ extern void _low_romdata[];
 extern int _len_data;
 
 
-#define SPL_STACK_SIZE				1024
+#define SPL_STACK_SIZE				1536
 #define HEAP_LEN ((int)_stack - (int)_heapbot - SPL_STACK_SIZE)
 
 // VDP specific (for VDU 23,0,n commands)

--- a/src/mos.h
+++ b/src/mos.h
@@ -50,6 +50,19 @@ typedef struct {
 	FIL		fileObject;
 } t_mosFileObject;
 
+/**
+ * MOS-specific return codes
+ * These extend the FatFS return codes FRESULT
+ */
+typedef enum {
+	MOS_INVALID_COMMAND = 20,	/* (20) Command could not be understood */
+	MOS_INVALID_EXECUTABLE, 	/* (21) Executable file format not recognised */
+	MOS_OUT_OF_MEMORY,			/* (22) Generic out of memory error NB this is currently unused */
+	MOS_NOT_IMPLEMENTED,		/* (23) API call not implemented */
+	MOS_OVERLAPPING_SYSTEM,		/* (24) File load prevented to stop overlapping system memory */
+	MOS_BAD_STRING,				/* (25) Bad or incomplete string */
+} MOSRESULT;
+
 void 	mos_error(int error);
 
 BYTE	mos_getkey(void);
@@ -90,6 +103,7 @@ int		mos_cmdHELP(char *ptr);
 int		mos_cmdHOTKEY(char *ptr);
 int		mos_cmdMEM(char *ptr);
 int		mos_cmdECHO(char *ptr);
+int		mos_cmdPRINTF(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -141,7 +155,8 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_DELETE			"Delete a file or folder (must be empty)\r\n"
 #define HELP_DELETE_ARGS	"[-f] <filename>"
 
-#define HELP_ECHO			"Echo the command argument string to the screen\r\n"
+#define HELP_ECHO			"Echo sends a string to the VDU, after transformation\r\n"
+#define HELP_ECHO_ARGS		"<string>"
 
 #define HELP_EXEC			"Run a batch file containing MOS commands\r\n"
 #define HELP_EXEC_ARGS		"<filename>"
@@ -158,6 +173,9 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_MKDIR			"Create a new folder on the SD card\r\n"
 #define HELP_MKDIR_ARGS		"<filename>"
+
+#define HELP_PRINTF			"Print a string to the VDU, with common unix-style escapes\r\n"
+#define HELP_PRINTF_ARGS	"<string>"
 
 #define HELP_RENAME			"Rename a file in the same folder\r\n"
 #define HELP_RENAME_ARGS	"<filename1> <filename2>"

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -149,49 +149,49 @@ $$:			AND	7Fh			; Else remove the top bit
 			JP	NC, mos_api_not_implemented
 			CALL	SWITCH_A		; And switch on this table
 
-mos_api_block2_start:	DW	ffs_api_fopen
-			DW	ffs_api_fclose
-			DW	ffs_api_fread
-			DW	ffs_api_fwrite
-			DW	ffs_api_flseek
-			DW	ffs_api_ftruncate
-			DW	ffs_api_fsync
-			DW	ffs_api_fforward
-			DW	ffs_api_fexpand
-			DW	ffs_api_fgets
-			DW	ffs_api_fputc
-			DW	ffs_api_fputs
-			DW	ffs_api_fprintf
-			DW	ffs_api_ftell
-			DW	ffs_api_feof
-			DW	ffs_api_fsize
-			DW	ffs_api_ferror
-			DW	ffs_api_dopen
-			DW	ffs_api_dclose
-			DW	ffs_api_dread
-			DW	ffs_api_dfindfirst
-			DW	ffs_api_dfindnext
-			DW	ffs_api_stat
-			DW	ffs_api_unlink
-			DW	ffs_api_rename
-			DW	ffs_api_chmod
-			DW	ffs_api_utime
-			DW	ffs_api_mkdir
-			DW	ffs_api_chdir
-			DW	ffs_api_chdrive
-			DW	ffs_api_getcwd
-			DW	ffs_api_mount
-			DW	ffs_api_mkfs
-			DW	ffs_api_fdisk		
-			DW	ffs_api_getfree
-			DW	ffs_api_getlabel
-			DW	ffs_api_setlabel
-			DW	ffs_api_setcp
+mos_api_block2_start:	DW	ffs_api_fopen		; 0x80
+			DW	ffs_api_fclose		; 0x81
+			DW	ffs_api_fread		; 0x82
+			DW	ffs_api_fwrite		; 0x83
+			DW	ffs_api_flseek		; 0x84
+			DW	ffs_api_ftruncate	; 0x85
+			DW	ffs_api_fsync		; 0x86
+			DW	ffs_api_fforward	; 0x87
+			DW	ffs_api_fexpand		; 0x88
+			DW	ffs_api_fgets		; 0x89
+			DW	ffs_api_fputc		; 0x8A
+			DW	ffs_api_fputs		; 0x8B
+			DW	ffs_api_fprintf		; 0x8C
+			DW	ffs_api_ftell		; 0x8D
+			DW	ffs_api_feof		; 0x8E
+			DW	ffs_api_fsize		; 0x8F
+			DW	ffs_api_ferror		; 0x90
+			DW	ffs_api_dopen		; 0x91
+			DW	ffs_api_dclose		; 0x92
+			DW	ffs_api_dread		; 0x93
+			DW	ffs_api_dfindfirst	; 0x94
+			DW	ffs_api_dfindnext	; 0x95
+			DW	ffs_api_stat		; 0x96
+			DW	ffs_api_unlink		; 0x97
+			DW	ffs_api_rename		; 0x98
+			DW	ffs_api_chmod		; 0x99
+			DW	ffs_api_utime		; 0x9A
+			DW	ffs_api_mkdir		; 0x9B
+			DW	ffs_api_chdir		; 0x9C
+			DW	ffs_api_chdrive		; 0x9D
+			DW	ffs_api_getcwd		; 0x9E
+			DW	ffs_api_mount		; 0x9F
+			DW	ffs_api_mkfs		; 0xA0
+			DW	ffs_api_fdisk		; 0xA1
+			DW	ffs_api_getfree		; 0xA2
+			DW	ffs_api_getlabel	; 0xA3
+			DW	ffs_api_setlabel	; 0xA4
+			DW	ffs_api_setcp		; 0xA5
 
 mos_api_block2_size:	EQU 	($ - mos_api_block2_start) / 2
 
 mos_api_not_implemented:
-			LD	HL, 23			; FR_MOS_NOT_IMPLEMENTED
+			LD	HL, 23			; MOS_NOT_IMPLEMENTED
 			RET
 
 ; Get keycode

--- a/src_fatfs/ff.h
+++ b/src_fatfs/ff.h
@@ -276,9 +276,6 @@ typedef struct {
 
 /**
  * File function return code (FRESULT)
- *
- * Also used as MOS user program return codes, and augmented with non-fatfs codes
- * (see FR_MOS_xxx)
  */
 
 typedef enum {
@@ -302,12 +299,6 @@ typedef enum {
 	FR_NOT_ENOUGH_CORE,		/* (17) LFN working buffer could not be allocated */
 	FR_TOO_MANY_OPEN_FILES,	/* (18) Number of open files > FF_FS_LOCK */
 	FR_INVALID_PARAMETER,	/* (19) Given parameter is invalid */
-	// additional error codes specific to MOS
-	FR_MOS_INVALID_COMMAND, /* (20) */
-	FR_MOS_INVALID_EXECUTABLE, /* (21) */
-	FR_MOS_OUT_OF_MEMORY, /* (22) */
-	FR_MOS_NOT_IMPLEMENTED, /* (23) */
-	FR_MOS_OVERLAPPING_SYSTEM, /* (24) */
 } FRESULT;
 
 

--- a/src_fatfs/ffsystem.c
+++ b/src_fatfs/ffsystem.c
@@ -12,7 +12,7 @@
 /* Allocate a memory block                                                */
 /*------------------------------------------------------------------------*/
 
-void* ff_meumm_malloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
+void* ff_memalloc (	/* Returns pointer to the allocated memory block (null if not enough core) */
 	UINT msize		/* Number of bytes to allocate */
 )
 {
@@ -24,7 +24,7 @@ void* ff_meumm_malloc (	/* Returns pointer to the allocated memory block (null i
 /* Free a memory block                                                    */
 /*------------------------------------------------------------------------*/
 
-void ff_memumm_free (
+void ff_memfree (
 	void* mblock	/* Pointer to the memory block to umm_free (nothing to do if null) */
 )
 {


### PR DESCRIPTION
Hey @tomm - as per comments I'd made on your PR, and chat on the discord, here's my changes that add a new echo

there's a few other minor tweaks in here, such as bumping the stack size to 1.5kb, fixing the duff malloc function names in the fatfs code, and moving the MOS-specific return codes to a separate enum (as it's kinda bugged me that we've been re-using the fatfs FRESULT enum)

I've kept your version of echo in there, just renamed it to be `printf`.  sure, it's not a _true_ printf, but is similar enough to it, and we can look to expand it in the future, should we choose to do so